### PR TITLE
Modified item 'Add to Cart' button based on status

### DIFF
--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,8 +4,11 @@
 
 <%= image_tag @item.image.url(:medium), class: "image" %>
 <p>Price: <%= number_to_currency(@item.price) %></p>
-<%= button_to "Add to Cart", cart_path(item_id: @item.id) %>
-
+  <% if @item.active? %>
+    <%= button_to "Add to Cart", cart_path(item_id: @item.id) %>
+  <% else %>
+    <%= button_to "Item Retired", cart_path(item_id: @item.id), :disabled => true %>
+  <% end %>
   <h3>Related Items</h3>
 <div class="related">
   <% @item.category.items.each do |item| %>

--- a/spec/features/user_can_not_add_item_if_status_retired_spec.rb
+++ b/spec/features/user_can_not_add_item_if_status_retired_spec.rb
@@ -7,20 +7,24 @@ RSpec.describe "User can't add item to cart" do
 
   scenario "if item status is retired, OBVIOUSLY" do
     visit item_path(item1)
+# save_and_open_page
 
     expect(page).to have_button("Add to Cart")
     expect(page).to have_content(item1.title)
     expect(page).to have_content(item1.description)
     expect(page).to have_content(item1.price)
+    expect(page).to have_link("Cart (0)")
 
     click_on "Add to Cart"
 
     expect(current_path).to eq(items_path)
+    expect(page).to have_link("Cart (1)")
 
     visit item_path(item2)
 
     expect(page).not_to have_button("Add to Cart")
     expect(page).to have_button("Item Retired", disabled: true)
+    expect(page).to have_link("Cart (1)")
     expect(page).to have_content(item2.title)
     expect(page).to have_content(item2.description)
     expect(page).to have_content(item2.price)

--- a/spec/features/user_can_not_add_item_if_status_retired_spec.rb
+++ b/spec/features/user_can_not_add_item_if_status_retired_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "User can't add item to cart" do
 
   scenario "if item status is retired, OBVIOUSLY" do
     visit item_path(item1)
-# save_and_open_page
 
     expect(page).to have_button("Add to Cart")
     expect(page).to have_content(item1.title)

--- a/spec/features/user_can_not_add_item_if_status_retired_spec.rb
+++ b/spec/features/user_can_not_add_item_if_status_retired_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe "User can't add item to cart" do
+  let!(:category1) { create(:category) }
+  let!(:item1) { create(:item, category: category1) }
+  let!(:item2) { create(:item, status: 1, category: category1) }
+
+  scenario "if item status is retired, OBVIOUSLY" do
+    visit item_path(item1)
+
+    expect(page).to have_button("Add to Cart")
+    expect(page).to have_content(item1.title)
+    expect(page).to have_content(item1.description)
+    expect(page).to have_content(item1.price)
+
+    click_on "Add to Cart"
+
+    expect(current_path).to eq(items_path)
+
+    visit item_path(item2)
+
+    expect(page).not_to have_button("Add to Cart")
+    expect(page).to have_button("Item Retired", disabled: true)
+    expect(page).to have_content(item2.title)
+    expect(page).to have_content(item2.description)
+    expect(page).to have_content(item2.price)
+  end
+end


### PR DESCRIPTION
### Description
Modified 'Add to Cart' button on show page

#### closes #87, closes #88, closes #86 

## Changes
Created conditional for items 'Add to Cart' button on show page. If items status is active, 'Add to Cart' button will be displayed, otherwise if item status is retired then 'Item Retired' button will be displayed and rendered disabled. In the event that an item is retired, a user can not click on 'Item Retired' button. Because it's disabled, OBVIOUSLY.

Also, created feature spec based on scenario.