### PR TITLE
Security

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -3,7 +3,7 @@
     <p><%= item.title %></p>
     <p><%= item.description %></p>
     <p><%= number_to_currency(item.price) %></p>
-    <div class="image"><%= image_tag item.image.url(:thumb) %></div>
+    <div class="image"><%= link_to image_tag(item.image.url(:thumb)), item_path(item) %></div>
     <%= button_to "Add to Cart", cart_path(item_id: item.id) %>
   </div>
 <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -14,7 +14,7 @@
   <% @item.category.items.each do |item| %>
     <div class="items">
       <p><%= link_to "#{item.title}", item_path(item) %></p>
-      <%= image_tag item.image.url(:thumb), class: "image" %>
+      <%= link_to image_tag(item.image.url(:thumb)), item_path(item), class: "image" %>
     </div>
   <% end %>
 </div>

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :user do
+    sequence :first_name do
+      Faker::Name.first_name
+    end
+
+    sequence :last_name do
+      Faker::Name.last_name
+    end
+
+    sequence :email do
+      Faker::Internet.email
+    end
+
+    sequence :address do
+      Faker::HarryPotter.location
+    end
+
+    sequence :password do
+      Faker::Internet.password
+    end
+
+    role 0
+  end
+end
+
+
+
+

--- a/spec/features/unauthenticated_users_cannot_view_other_users_data_spec.rb
+++ b/spec/features/unauthenticated_users_cannot_view_other_users_data_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe 'Unauthenticated users' do
+  xit 'cannot view other users private data' do
+    visit '/'
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_link("Log In")
+
+    click_on "The Conservatory"
+
+    visit '/dashboard'
+
+    expect(page.status_code).to eq(404)
+
+    visit '/orders'
+
+    expect(page.status_code).to eq(404)
+  end
+end

--- a/spec/features/user_can_create_account_spec.rb
+++ b/spec/features/user_can_create_account_spec.rb
@@ -12,12 +12,17 @@ RSpec.describe 'User can create an account' do
 
     fill_in "user[first_name]", with: "Emma"
     fill_in "user[last_name]", with: "Swan"
-    fill_in "user[address]", with: "123 Lane Storybrooke, MA 23451"
+    fill_in "user[address]", with: "123 Storybrooke Lane, MA 23451"
     fill_in "user[email]", with: "swan@ouat.com"
     fill_in "user[password]", with: "Henry"
 
     click_on "Register"
 
+    user = User.last
+
     expect(current_path).to eq(dashboard_path)
+    expect(page).to have_content("#{user.first_name}")
+    expect(page).to have_content("#{user.last_name}")
+    expect(page).to have_content("#{user.address}")
   end
 end

--- a/spec/features/user_can_see_only_their_own_spec.rb
+++ b/spec/features/user_can_see_only_their_own_spec.rb
@@ -1,32 +1,84 @@
 require 'rails_helper'
 
 RSpec.describe 'Users can only see their own data' do
-  let!(:user) { create(:user) }
-  let!(:admin) { create(:user, role: 1) }
+  let!(:user)       { create(:user) }
+  let!(:other_user) { create(:user) }
+  let!(:admin)      { create(:user, role: 1) }
 
-  it 'user can not view anohter users private data' do
+  it 'user can not view another users private data' do
+    visit login_path
 
+    expect(current_path).to eq("/login")
+    expect(page).to have_content("Log In")
+    expect(page).to have_button("Submit")
+    expect(page).to have_link("Register")
 
+    fill_in "session[email]",    with: "#{user.email}"
+    fill_in "session[password]", with: "#{user.password}"
+
+    click_on "Submit"
+
+    expect(current_path).to eq('/dashboard')
+    expect(page).to have_content("#{user.first_name} #{user.last_name}")
+    expect(page).to have_content("#{user.address}")
+    expect(page).not_to have_content("#{other_user.first_name} #{other_user.last_name}")
+    expect(page).not_to have_content("#{other_user.address}")
+    expect(page).not_to have_content("#{admin.first_name} #{admin.last_name}")
+    expect(page).not_to have_content("#{admin.address}")
+  end
+
+  it 'user cannot see other users order info' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    order = user.orders.create
+
+    visit orders_path
+
+    expect(current_path).to eq('/orders')
+    expect(page).to have_content("#{order.id}")
+    expect(page).to have_content("#{order.format_date}")
+    expect(page).to have_button("View Order")
   end
 
   it 'user cannot view an administrators screen' do
+    visit login_path
 
-  end
+    fill_in "session[email]",    with: "#{user.email}"
+    fill_in "session[password]", with: "#{user.password}"
 
-  it 'user cannot use admin functionality' do
+    click_on "Submit"
 
+    expect(current_path).to eq('/dashboard')
+    expect(page).to have_content("#{user.first_name} #{user.last_name}")
+    expect(page).to have_content("#{user.address}")
+
+    visit admin_dashboard_path
+
+    expect(page.status_code).to eq(404)
+    expect(page).to have_content("The page you were looking for doesn't exist.")
   end
 
   it 'user cannot make themself an admin' do
+    visit login_path
 
+    click_on "Register"
+
+    fill_in "user[first_name]", with: "Emma"
+    fill_in "user[last_name]",  with: "Swan"
+    fill_in "user[address]",    with: "123 Storybrooke Lane, MA 23451"
+    fill_in "user[email]",      with: "swan@ouat.com"
+    fill_in "user[password]",   with: "Henry"
+
+    expect(page).not_to have_content("Role")
+    expect(page).not_to have_content("Admin")
+
+    click_on "Register"
+
+    user = User.last
+
+    expect(current_path).to eq(dashboard_path)
+    expect(user.admin?).to be false
+    expect(page).to have_content("#{user.first_name}")
+    expect(page).to have_content("#{user.last_name}")
   end
 end
-
-
-
-# Background: An authenticated user
-
-# As an Authenticated User
-# I cannot view another user’s private data (current or past orders, etc)
-# I cannot view the administrator screens or use admin functionality
-# I cannot make myself an admin

--- a/spec/features/user_can_see_only_their_own_spec.rb
+++ b/spec/features/user_can_see_only_their_own_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Users can only see their own data' do
+  let!(:user) { create(:user) }
+  let!(:admin) { create(:user, role: 1) }
+
+  it 'user can not view anohter users private data' do
+
+
+  end
+
+  it 'user cannot view an administrators screen' do
+
+  end
+
+  it 'user cannot use admin functionality' do
+
+  end
+
+  it 'user cannot make themself an admin' do
+
+  end
+end
+
+
+
+# Background: An authenticated user
+
+# As an Authenticated User
+# I cannot view another user’s private data (current or past orders, etc)
+# I cannot view the administrator screens or use admin functionality
+# I cannot make myself an admin

--- a/spec/features/visitor_can_view_item_show_page_spec.rb
+++ b/spec/features/visitor_can_view_item_show_page_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe 'Visitor can see item show page' do
     expect(page).to have_content(item1.description)
     expect(page).to have_css(".image")
     expect(page).to have_content(item1.price)
-    expect(page).to have_button("Add to Cart")    
+    expect(page).to have_button("Add to Cart")
   end
 end


### PR DESCRIPTION
### Description
Created spec for story 16, authenticated user can only see their own private data, does not have admin capabilities, can not make themselves admin, can not see admin pages.

Created user FactoryBot for testing, and made item images in index page clickable images that navigate to item show pages. Random, yes. Necessary? Only if you wanted a clickable way to view the item show page...so, yes.

#### closes #94 , closes #95 

## Proposed Changes
Story 17 feature spec started - have yet to complete

All tests passing, one skipped because spec for story 17 in progress.

![screen shot 2017-11-03 at 11 52 42 pm](https://user-images.githubusercontent.com/27023122/32402851-4103ce5a-c0f2-11e7-84c2-091030f4ea5f.png)

